### PR TITLE
Modularize ui/server

### DIFF
--- a/inst/app.R
+++ b/inst/app.R
@@ -1,0 +1,21 @@
+library(shiny)
+library(shinyComponents)
+
+ex <- ShinyComponent$new("../inst/example-component.Rmd")
+
+ui <- fluidPage(
+  ex$ui("one", message = "This is cool"),
+  ex$ui("two", message = "I like it"),
+  ex$assets()
+)
+
+server <- function(input, output, session) {
+  ex$server("one")
+  two <- ex$server("two")
+
+  observe({
+    message("The value of 'two' is ", two())
+  })
+}
+
+shinyApp(ui, server)

--- a/inst/example-component.Rmd
+++ b/inst/example-component.Rmd
@@ -9,12 +9,19 @@ initial_header <- "Just a simple demo"
 
 ```{r ui}
 h3(initial_header)
-sliderInput("number", "Pick a number", min = 0, max = 10, value = 1)
-verbatimTextOutput("debug")
+p(message)
+sliderInput(ns("number"), "Pick a number", min = 0, max = 10, value = 1)
+verbatimTextOutput(ns("debug"))
 ```
 
 ```{r server}
-output$debug <- renderPrint(input$number)
+function(id) {
+  moduleServer(id, function(input, output, session) {
+    output$debug <- renderPrint(input$number)
+    
+    return(reactive(input$number))
+  })
+}
 ```
 
 ```{css}


### PR DESCRIPTION
The main design principle behind Shiny modules was that the id's of inputs
and outputs should be locally scoped. This was necessary to allow 1) multiple
independent copies of the same module to be included in the same page, and
2) to allow module authors to modify module code without worrying about
accidentally breaking apps that happen to use the same input/output ID. I
think these goals are equally applicable to shinyComponents.

A second principle is that modularized server functions should communicate
with their callers via return values, not by assignment into a shared env.
Again, I think that applies here too.

This commit makes ui and server chunks behave more like their Shiny module
versions of themselves. For ui chunks, all input/output IDs need to be
wrapped in ns() (which is automatically injected into the environment). Calls
to ex$ui() need to include an id as their first argument, which can be any
identifier string as long as it matches a corresponding ex$server() call.
You can also add other (named) arguments to the ex$ui() call; these will be
added to the call_env as well.

For server chunks, instead of just putting server logic in there, you need
to put a module server function (see the changes to example-component.Rmd).
Any additional arguments to ex$server() are passed along to the module server
function.

Of course, Shiny modules come with their own syntactic overhead, so maybe
module-ness isn't something that should be required for every shinyComponent,
but something that could be opted into with a chunk option. This commit
doesn't do that, it just changes the hardcoded behavior of ui and server.